### PR TITLE
add missing deps to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,17 @@ include_package_data = True
 zip_safe = False
 
 install_requires =
-    ipycytoscape
+    bokeh
+    datashader
+    holoviews
+    ipycytoscape >=1.0.3
     ipywidgets
+    networkx
     pandas
     qgrid
     rdflib
     rdflib-jsonld
+    scikit-image
 
 [options.packages.find]
 where =


### PR DESCRIPTION
Noticed this while working on the conda-forge package.

- [x] adds all deps formerly from conda recipe to setup.cfg