### PR TITLE
Remove qgrid

### DIFF
--- a/.github/workflows/ciV0.yml
+++ b/.github/workflows/ciV0.yml
@@ -12,7 +12,7 @@ env:
   INSTALL_ARTIFACT: wheel
   CONDA_EXE: mamba
   FORGE_BASE: https://github.com/conda-forge/miniforge/releases/download/4.9.2-5/Mambaforge-4.9.2-5
-  CACHE_EPOCH: 0
+  CACHE_EPOCH: 1
 
 jobs:
   ci:

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ For JupyterLab support, ensure you have the following installed:
 
 ## JupyterLab compatibility
 
-While `ipyradiant` doesn't provide any JupyterLab extensions, it depends on a
-number of them.
+While `ipyradiant` doesn't provide any JupyterLab extensions, it depends on a number of
+them.
 
-The release of JupyterLab 3 has made some version compatibility unpredictable.
-Below are some researched combinations that should work.
+The release of JupyterLab 3 has made some version compatibility unpredictable. Below are
+some researched combinations that should work.
 
 | `jupyterlab` | `ipycytoscape`   | `pyviz_comms` | `pip install`      |
-| ------------ | ---------------- | ------------- |--------------------|
+| ------------ | ---------------- | ------------- | ------------------ |
 | `>=1,<2`     | `>=1.0.3,<1.1.0` | `>=1,<1.0.3`  | `ipyradiant[lab1]` |
 | `>=2,<3`     | `>=1.0.3,<1.1.0` | `>=1,<1.0.3`  | `ipyradiant[lab2]` |
 | `>=3,<4`     | `>=1.1.0`        | `>=1.0.3`     | `ipyradiant[lab3]` |

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ in [JupyterLab][jupyterlab].
 Powered by [ipyctoscape][ipycytoscape], [datashader][datashader], and
 [holoviews][holoviews].
 
-## JupyterLab compatibility
-
-| `jupyterlab` | `ipycytoscape`   | `pyviz_comms` |
-| ------------ | ---------------- | ------------- |
-| `>=1,<2`     | `>=1.0.3,<1.1.0` | `>=1,<1.0.3`  |
-
 ## Visualization Widgets
 
 `ipyradiant` includes several widgets for visualizing and interacting with RDF graphs
@@ -37,6 +31,20 @@ For JupyterLab support, ensure you have the following installed:
 
 - `jupyterlab >=1`
 - `nodejs >=10`
+
+## JupyterLab compatibility
+
+While `ipyradiant` doesn't provide any JupyterLab extensions, it depends on a
+number of them.
+
+The release of JupyterLab 3 has made some version compatibility unpredictable.
+Below are some researched combinations that should work.
+
+| `jupyterlab` | `ipycytoscape`   | `pyviz_comms` | `pip install`      |
+| ------------ | ---------------- | ------------- |--------------------|
+| `>=1,<2`     | `>=1.0.3,<1.1.0` | `>=1,<1.0.3`  | `ipyradiant[lab1]` |
+| `>=2,<3`     | `>=1.0.3,<1.1.0` | `>=1,<1.0.3`  | `ipyradiant[lab2]` |
+| `>=3,<4`     | `>=1.1.0`        | `>=1.0.3`     | `ipyradiant[lab3]` |
 
 ## Install
 

--- a/anaconda-project-lock.yml
+++ b/anaconda-project-lock.yml
@@ -19,7 +19,7 @@ env_specs:
     locked: false
   dev:
     locked: true
-    env_spec_hash: e1b58f93426c55365bde30d4c55de491b508c19a
+    env_spec_hash: 01d693614c5a299d444efa1113601abc002f0de9
     platforms:
       - linux-64
       - osx-64
@@ -32,7 +32,7 @@ env_specs:
         - backcall=0.2.0=pyh9f0ad1d_0
         - backports.functools_lru_cache=1.6.1=py_0
         - backports=1.0=py_2
-        - bleach=3.2.1=pyh9f0ad1d_0
+        - bleach=3.2.2=pyh44b312d_0
         - cachetools=4.1.1=py_0
         - click=7.1.2=pyh9f0ad1d_0
         - cloudpickle=1.6.0=py_0
@@ -84,7 +84,7 @@ env_specs:
         - pip=20.3.3=pyhd8ed1ab_0
         - pooch=1.3.0=pyhd8ed1ab_0
         - prometheus_client=0.9.0=pyhd3deb0d_0
-        - prompt-toolkit=3.0.10=pyha770c72_0
+        - prompt-toolkit=3.0.11=pyha770c72_0
         - py=1.10.0=pyhd3deb0d_0
         - pycparser=2.20=pyh9f0ad1d_2
         - pyct-core=0.4.6=py_0
@@ -99,7 +99,6 @@ env_specs:
         - python_abi=3.7=1_cp37m
         - pytz=2020.5=pyhd8ed1ab_0
         - pyviz_comms=0.7.6=pyh9f0ad1d_0
-        - qgrid=1.3.1=py37hc8dfbb8_1
         - requests=2.25.1=pyhd3deb0d_0
         - requests_cache=0.4.13=py_0
         - send2trash=1.5.0=py_0
@@ -153,12 +152,12 @@ env_specs:
         - imagecodecs=2021.1.11=py37h95c7a1b_1
         - importlib-metadata=3.4.0=py37h89c1867_0
         - importlib_resources=5.1.0=py37h89c1867_0
-        - ipykernel=5.4.2=py37h888b3d9_0
+        - ipykernel=5.4.3=py37h888b3d9_0
         - ipython=7.19.0=py37h888b3d9_2
         - jedi=0.17.2=py37hc8dfbb8_1
         - jpeg=9d=h516909a_0
         - jsonschema=3.2.0=py37hc8dfbb8_1
-        - jupyter_core=4.7.0=py37h89c1867_0
+        - jupyter_core=4.7.0=py37h89c1867_1
         - jxrlib=1.1=h516909a_2
         - keepalive=0.5=py37h89c1867_5
         - kiwisolver=1.3.1=py37h2527ec5_1
@@ -212,8 +211,8 @@ env_specs:
         - pytest=6.2.1=py37h89c1867_1
         - python=3.7.9=hffdb5ce_0_cpython
         - pywavelets=1.1.1=py37h161383b_3
-        - pyyaml=5.3.1=py37h5e8e339_2
-        - pyzmq=21.0.1=py37h499b945_0
+        - pyyaml=5.4.1=py37h5e8e339_0
+        - pyzmq=20.0.0=py37h499b945_1
         - rdflib-jsonld=0.5.0=py37hc8dfbb8_2
         - rdflib=5.0.0=py37hc8dfbb8_3
         - readline=8.0=he28a2e2_2
@@ -265,14 +264,14 @@ env_specs:
         - jedi=0.18.0=py37hf985489_2
         - jpeg=9d=hbcb3906_0
         - jsonschema=3.2.0=py_2
-        - jupyter_core=4.7.0=py37hf985489_0
+        - jupyter_core=4.7.0=py37hf985489_1
         - jxrlib=1.1=h35c211d_2
         - keepalive=0.5=py37hf985489_5
         - kiwisolver=1.3.1=py37h70f7d40_1
         - lcms2=2.11=h11f7e16_1
         - lerc=2.2.1=h046ec9c_0
         - libaec=1.0.4=h046ec9c_1
-        - libcxx=11.0.0=h4c3b8ed_1
+        - libcxx=11.0.1=habf9029_0
         - libdeflate=1.7=h35c211d_5
         - libffi=3.3=h046ec9c_2
         - libgfortran5=9.3.0=h6c81a4c_16
@@ -317,7 +316,7 @@ env_specs:
         - pytest=6.2.1=py37hf985489_1
         - python=3.7.9=h6c3b2c9_0_cpython
         - pywavelets=1.1.1=py37h37391d0_3
-        - pyyaml=5.3.1=py37hf967b71_2
+        - pyyaml=5.4.1=py37hf967b71_0
         - pyzmq=21.0.1=py37h4c5583b_0
         - rdflib-jsonld=0.5.0=py37hf985489_2
         - rdflib=5.0.0=py37hf985489_3
@@ -370,7 +369,7 @@ env_specs:
         - jedi=0.18.0=py37h03978a9_2
         - jpeg=9d=h8ffe710_0
         - jsonschema=3.2.0=py_2
-        - jupyter_core=4.7.0=py37h03978a9_0
+        - jupyter_core=4.7.0=py37h03978a9_1
         - jxrlib=1.1=h8ffe710_2
         - keepalive=0.5=py37h03978a9_5
         - kiwisolver=1.3.1=py37h8c56517_1
@@ -424,7 +423,7 @@ env_specs:
         - pywavelets=1.1.1=py37hda49f71_3
         - pywin32=300=py37hcc03f2d_0
         - pywinpty=0.5.7=py37hc8dfbb8_1
-        - pyyaml=5.3.1=py37hcc03f2d_2
+        - pyyaml=5.4.1=py37hcc03f2d_0
         - pyzmq=21.0.1=py37h0d95fc2_0
         - rdflib-jsonld=0.5.0=py37h03978a9_2
         - rdflib=5.0.0=py37h03978a9_3
@@ -466,7 +465,7 @@ env_specs:
         - backports.functools_lru_cache=1.6.1=py_0
         - backports=1.0=py_2
         - black=20.8b1=py_1
-        - bleach=3.2.1=pyh9f0ad1d_0
+        - bleach=3.2.2=pyh44b312d_0
         - click=7.1.2=pyh9f0ad1d_0
         - decorator=4.4.2=py_0
         - defusedxml=0.6.0=py_0
@@ -489,7 +488,7 @@ env_specs:
         - pandocfilters=1.4.2=py_1
         - pathspec=0.8.1=pyhd3deb0d_0
         - prometheus_client=0.9.0=pyhd3deb0d_0
-        - prompt-toolkit=3.0.10=pyha770c72_0
+        - prompt-toolkit=3.0.11=pyha770c72_0
         - pycodestyle=2.6.0=pyh9f0ad1d_0
         - pycparser=2.20=pyh9f0ad1d_2
         - pyflakes=2.2.0=pyh9f0ad1d_0
@@ -525,11 +524,11 @@ env_specs:
         - entrypoints=0.3=py37hc8dfbb8_1002
         - icu=68.1=h58526e2_0
         - importlib-metadata=3.4.0=py37h89c1867_0
-        - ipykernel=5.4.2=py37h888b3d9_0
+        - ipykernel=5.4.3=py37h888b3d9_0
         - ipython=7.19.0=py37h888b3d9_2
         - jedi=0.17.2=py37hc8dfbb8_1
         - jsonschema=3.2.0=py37hc8dfbb8_1
-        - jupyter_core=4.7.0=py37h89c1867_0
+        - jupyter_core=4.7.0=py37h89c1867_1
         - ld_impl_linux-64=2.35.1=hed1e6ac_1
         - libffi=3.3=h58526e2_2
         - libgcc-ng=9.3.0=h2828fa1_18
@@ -552,7 +551,7 @@ env_specs:
         - pyrsistent=0.17.3=py37h5e8e339_2
         - pysocks=1.7.1=py37h89c1867_3
         - python=3.7.9=hffdb5ce_0_cpython
-        - pyzmq=21.0.1=py37h499b945_0
+        - pyzmq=20.0.0=py37h499b945_1
         - readline=8.0=he28a2e2_2
         - regex=2020.11.13=py37h5e8e339_1
         - setuptools=49.6.0=py37h89c1867_3
@@ -581,8 +580,8 @@ env_specs:
         - ipython=7.18.1=py37hc6149b9_1
         - jedi=0.18.0=py37hf985489_2
         - jsonschema=3.2.0=py_2
-        - jupyter_core=4.7.0=py37hf985489_0
-        - libcxx=11.0.0=h4c3b8ed_1
+        - jupyter_core=4.7.0=py37hf985489_1
+        - libcxx=11.0.1=habf9029_0
         - libffi=3.3=h046ec9c_2
         - libsodium=1.0.18=hbcb3906_1
         - libuv=1.40.0=h35c211d_0
@@ -629,7 +628,7 @@ env_specs:
         - ipython=7.18.1=py37hc6149b9_1
         - jedi=0.18.0=py37h03978a9_2
         - jsonschema=3.2.0=py_2
-        - jupyter_core=4.7.0=py37h03978a9_0
+        - jupyter_core=4.7.0=py37h03978a9_1
         - libsodium=1.0.18=h8d14728_1
         - m2w64-gcc-libgfortran=5.3.0=6
         - m2w64-gcc-libs-core=5.3.0=7
@@ -674,7 +673,7 @@ env_specs:
       - win-64
     packages:
       all:
-        - bleach=3.2.1=pyh9f0ad1d_0
+        - bleach=3.2.2=pyh44b312d_0
         - colorama=0.4.4=pyh9f0ad1d_0
         - conda=4.8.3=py37hc8dfbb8_1
         - idna=2.10=pyh9f0ad1d_0
@@ -752,7 +751,7 @@ env_specs:
         - docutils=0.16=py37hf985489_3
         - importlib-metadata=3.4.0=py37hf985489_0
         - keyring=21.8.0=py37hf985489_0
-        - libcxx=11.0.0=h4c3b8ed_1
+        - libcxx=11.0.1=habf9029_0
         - libffi=3.3=h046ec9c_2
         - ncurses=6.2=h2e338ed_4
         - openssl=1.1.1i=h35c211d_0

--- a/anaconda-project.yml
+++ b/anaconda-project.yml
@@ -87,7 +87,6 @@ env_specs:
       - pyld
       - pyshacl
       - python >=3.6 # underspecified so binder does whatever's clever
-      - qgrid
       - rdflib-jsonld
       - requests_cache
       - scikit-image

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,6 @@ dependencies:
   - pyld
   - pyshacl
   - python >=3.6 # underspecified so binder does whatever's clever
-  - qgrid
   - rdflib-jsonld
   - requests_cache
   - scikit-image

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ install_requires =
     ipywidgets
     networkx >=2
     pandas
-    qgrid
     rdflib
     rdflib-jsonld
     scikit-image
@@ -46,6 +45,24 @@ install_requires =
 [options.packages.find]
 where =
     src
+
+[options.extras_require]
+# a known-good jupyterlab 1 combination, requires `jupyter lab build`
+lab1 =
+    jupyterlab ==1.*
+    ipycytoscape <1.1.0
+    pyviz_comms >=1,<1.0.3
+# an (untested) jupyterlab 2 combination, requires `jupyter lab build`
+lab2 =
+    jupyterlab ==1.*
+    ipycytoscape <1.1.0
+    pyviz_comms >=1,<1.0.3
+# an (untested) jupyterlab 3 combination
+lab3 =
+    jupyterlab ==3.*
+    ipycytoscape >=1.2.0
+    pyviz_comms >=1.0.3
+
 
 [flake8]
 max-line-length = 88

--- a/src/ipyradiant/query/query_widget.py
+++ b/src/ipyradiant/query/query_widget.py
@@ -5,6 +5,7 @@
 
 import re
 
+import IPython as I
 import ipywidgets as W
 import traitlets as T
 from pandas import DataFrame
@@ -59,7 +60,7 @@ class QueryWidget(W.VBox):
                     collapsed_data.iat[ii, jj] = collapse_namespace(namespaces, cell)
         self.grid.clear_output()
         with self.grid:
-            IPython.display(collapsed_data)
+            I.display.display(I.display.HTML(collapsed_data.to_html(escape=False)))
 
     @T.default("graph")
     def make_default_graph(self):
@@ -67,7 +68,7 @@ class QueryWidget(W.VBox):
 
     @T.default("grid")
     def make_default_grid(self):
-        return W.Output()
+        return W.Output(layout=dict(max_height="60vh"))
 
     @T.default("run_button")
     def make_default_run_button(self):

--- a/src/ipyradiant/query/query_widget.py
+++ b/src/ipyradiant/query/query_widget.py
@@ -5,7 +5,7 @@
 
 import re
 
-import IPython as I
+import IPython
 import ipywidgets as W
 import traitlets as T
 from pandas import DataFrame
@@ -60,7 +60,9 @@ class QueryWidget(W.VBox):
                     collapsed_data.iat[ii, jj] = collapse_namespace(namespaces, cell)
         self.grid.clear_output()
         with self.grid:
-            I.display.display(I.display.HTML(collapsed_data.to_html(escape=False)))
+            IPython.display.display(
+                IPython.display.HTML(collapsed_data.to_html(escape=False))
+            )
 
     @T.default("graph")
     def make_default_graph(self):


### PR DESCRIPTION
[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/nrbgt/ipyradiant/remove-qgrid?urlpath=lab)

`qgrid` is a a troublesome hard dependency. This removes it, replacing its use in the query widget with a dump of the pandas HTML in an `Output`:

![Screenshot from 2021-01-22 11-24-37](https://user-images.githubusercontent.com/7581399/105516935-6ee7a980-5ca4-11eb-9670-74f9edb91c20.png)


While removing deps, it also hoists our "thought good" lab install profiles to `extras` and adds these to the docs.