### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # `ipyradiant` CHANGELOG
 
-## 0.2 (WIP)
+## 0.2.0 (WIP)
 
 - adds `InteractiveViewer` widget (small RDF graphs as LPG with type coloring)
 - adds `CytoscapeViewer` widget (common graph visualization for RDF and LPG i.e.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # `ipyradiant` CHANGELOG
 
-## 0.1.3 (WIP)
+## 0.2 (WIP)
 
 - adds `InteractiveViewer` widget (small RDF graphs as LPG with type coloring)
+- adds `CytoscapeViewer` widget (common graph visualization for RDF and LPG i.e.
+  networkx)
 - removes `InteractiveVisualization` widget
 - removes `GraphExplorer` widget and associated code/tests
 - improves `QueryWidget` layout and namespace resolution
+- improves `RDF2NX` converter by allowing multiple queries to be defined for each
+  behavior
+- improves reliability of `RDF2NX` converter via improved namespace management
 - support for `jupyterlab >= 3`
 
 ## 0.1.2 (J_e) (2021-01-21)

--- a/examples/RDF_to_NX_Custom.ipynb
+++ b/examples/RDF_to_NX_Custom.ipynb
@@ -268,10 +268,11 @@
     "\n",
     "The purpose of creating these projections is often to generate a view that is easier for\n",
     "humans to interpret (or to leverage graph algorithms for LPGs). The following cells\n",
-    "demonstrate how the `ipyradiant` visualization widget `InteractiveViewer` can be used\n",
-    "to visualize and inspect an LPG graph.\n",
+    "demonstrate how the `ipyradiant` visualization widget `InteractiveViewer` can be used to\n",
+    "visualize and inspect an LPG graph.\n",
     "\n",
-    "> Note: the option to remove disconnected nodes will be enabled on ticket [#110](https://github.com/jupyrdf/ipyradiant/issues/110)"
+    "> Note: the option to remove disconnected nodes will be enabled on ticket\n",
+    "> [#110](https://github.com/jupyrdf/ipyradiant/issues/110)"
    ]
   },
   {

--- a/src/ipyradiant/_version.py
+++ b/src/ipyradiant/_version.py
@@ -3,4 +3,4 @@
 # Copyright (c) 2021 ipyradiant contributors.
 # Distributed under the terms of the Modified BSD License.
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"


### PR DESCRIPTION
Very barebones PR changing the version from `0.1.3` to `0.2.0` prior to release.

Closes #105 